### PR TITLE
feat(auth-server): Finish Epic FHIR Launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 include .env
+
 ORG := keratin
 PROJECT := authn-server
 NAME := $(ORG)/$(PROJECT)
@@ -25,6 +26,21 @@ server: init
 	DATABASE_URL=sqlite3://localhost/dev \
 		REDIS_URL=redis://127.0.0.1:8701/11 \
 		nodemon --signal SIGTERM --exec go run -ldflags "-X main.VERSION=$(VERSION)" $(MAIN)
+
+.PHONY: devServer
+devServer: init
+	docker-compose up -d redis
+	DATABASE_URL=${DATABASE_URL} \
+		REDIS_URL=redis://127.0.0.1:8701/11 \
+		AUTHN_URL=${AUTHN_URL} \
+		nodemon --signal SIGTERM --exec go run -ldflags "-X main.VERSION=$(VERSION)" $(MAIN)
+
+.PHONY: devMigrate
+devMigrate: init
+	docker-compose up -d redis
+	DATABASE_URL=${DATABASE_URL} \
+		REDIS_URL=redis://
+		go run -ldflags "-X main.VERSION=$(VERSION)" $(MAIN) migrate
 
 # Run tests
 .PHONY: test

--- a/lib/smart_on_fhir/build_rsa_public_key.go
+++ b/lib/smart_on_fhir/build_rsa_public_key.go
@@ -1,0 +1,48 @@
+package smart_on_fhir
+
+import (
+	"fmt"
+
+	"bytes"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"math/big"
+)
+
+func buildRSAPublicKey(modulus string, exponent string) (*rsa.PublicKey, error) {
+	fmt.Println("===> Modulus:", modulus)
+	decodedModulus, err := base64.RawURLEncoding.DecodeString(modulus)
+	if err != nil {
+		return &rsa.PublicKey{}, err
+	}
+
+	bigN := big.NewInt(0)
+	bigN.SetBytes(decodedModulus)
+	if err != nil {
+		return &rsa.PublicKey{}, err
+	}
+
+	decodedExponent, err := base64.StdEncoding.DecodeString(exponent)
+	if err != nil {
+		return &rsa.PublicKey{}, err
+	}
+
+	var eBytes []byte
+	if len(decodedExponent) < 8 {
+		eBytes = make([]byte, 8-len(decodedExponent), 8)
+		eBytes = append(eBytes, decodedExponent...)
+	} else {
+		eBytes = decodedExponent
+	}
+
+	eReader := bytes.NewReader(eBytes)
+	var e uint64
+	err = binary.Read(eReader, binary.BigEndian, &e)
+	if err != nil {
+		return &rsa.PublicKey{}, err
+	}
+	pKey := rsa.PublicKey{N: bigN, E: int(e)}
+
+	return &pKey, nil
+}

--- a/lib/smart_on_fhir/request_access_token.go
+++ b/lib/smart_on_fhir/request_access_token.go
@@ -1,0 +1,52 @@
+package smart_on_fhir
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func RequestAccessToken(tokenUrl string, clientId string, clientSecret string, code string) (*FhirTokenResponse, error) {
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	// Set the form data for the request
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", code)
+	data.Set("redirect_uri", "http://localhost:21001/fhir/epic/return")
+	data.Set("client_id", clientId)
+	data.Set("client_secret", clientSecret)
+
+	encodedBody := data.Encode()
+
+	// Create the request
+	req, err := http.NewRequest("POST", tokenUrl, strings.NewReader(encodedBody))
+	if err != nil {
+		return nil, fmt.Errorf("got error %s", err.Error())
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	// Send the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the body
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+
+	// Unmarshal the body into the `target` struct and return
+	target := new(FhirTokenResponse)
+	err = json.Unmarshal(b, target)
+	if err != nil {
+		return nil, err
+	}
+	return target, nil
+}

--- a/lib/smart_on_fhir/utils.go
+++ b/lib/smart_on_fhir/utils.go
@@ -2,18 +2,8 @@ package smart_on_fhir
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strings"
-	"time"
-
-	"bytes"
-	"crypto/rsa"
-	"encoding/base64"
-	"encoding/binary"
-	"math/big"
 )
 
 func discoverAuthServer(issuer string, target interface{}) error {
@@ -44,8 +34,6 @@ func fetchEpicJWKS() (*EpicJwksResponse, error) {
 	epicConfig := new(OpenIDConfiguration)
 	json.Unmarshal(body, epicConfig)
 
-	fmt.Println("==> JWKS URI:", epicConfig.JwksURI)
-
 	jwksReq, _ := http.NewRequest("GET", epicConfig.JwksURI, nil)
 	jwksReq.Header.Add("Content-Type", "application/json")
 
@@ -60,95 +48,4 @@ func fetchEpicJWKS() (*EpicJwksResponse, error) {
 	json.Unmarshal(jwksBody, epicJwksResponse)
 
 	return epicJwksResponse, err
-}
-
-func RequestAccessToken(tokenUrl string, clientId string, clientSecret string, code string) (*FhirTokenResponse, error) {
-	client := &http.Client{
-		Timeout: time.Second * 10,
-	}
-
-	// Set the form data for the request
-	data := url.Values{}
-	data.Set("grant_type", "authorization_code")
-	data.Set("code", code)
-	data.Set("redirect_uri", "http://localhost:21001/fhir/epic/return/provider")
-	data.Set("client_id", clientId)
-	data.Set("client_secret", clientSecret)
-	encodedBody := data.Encode()
-
-	// Create the request
-	req, err := http.NewRequest("POST", tokenUrl, strings.NewReader(encodedBody))
-	if err != nil {
-		return nil, fmt.Errorf("got error %s", err.Error())
-	}
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	// Send the request
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	// Read the body
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
-
-	fmt.Println("==> RequestAccessToken Body:", string(b))
-
-	// Unmarshal the body into the `target` struct and return
-	target := new(FhirTokenResponse)
-	err = json.Unmarshal(b, target)
-	if err != nil {
-		return nil, err
-	}
-	return target, nil
-}
-
-func buildRSAPublicKey(modulus string, exponent string) (*rsa.PublicKey, error) {
-	fmt.Println("===> Modulus:", modulus)
-	decodedModulus, err := base64.RawURLEncoding.DecodeString(modulus)
-	if err != nil {
-		fmt.Println(err)
-		return &rsa.PublicKey{}, err
-	}
-
-	bigN := big.NewInt(0)
-	bigN.SetBytes(decodedModulus)
-	if err != nil {
-		fmt.Println(err)
-		return &rsa.PublicKey{}, err
-	}
-
-	fmt.Println("===> Decoded Modulus:", decodedModulus)
-	fmt.Println("===> BigN:", bigN)
-
-	decodedExponent, err := base64.StdEncoding.DecodeString(exponent)
-	if err != nil {
-		fmt.Println(err)
-		return &rsa.PublicKey{}, err
-	}
-
-	fmt.Println("===> Exponent:", exponent)
-	fmt.Println("===> Decoded Exponent:", decodedExponent)
-
-	var eBytes []byte
-	if len(decodedExponent) < 8 {
-		eBytes = make([]byte, 8-len(decodedExponent), 8)
-		eBytes = append(eBytes, decodedExponent...)
-	} else {
-		eBytes = decodedExponent
-	}
-
-	eReader := bytes.NewReader(eBytes)
-	var e uint64
-	err = binary.Read(eReader, binary.BigEndian, &e)
-	if err != nil {
-		fmt.Println(err)
-		return &rsa.PublicKey{}, err
-	}
-	pKey := rsa.PublicKey{N: bigN, E: int(e)}
-
-	fmt.Println("===> Public RSA Key", pKey)
-
-	return &pKey, nil
 }

--- a/server/handlers/get_fhir_launch.go
+++ b/server/handlers/get_fhir_launch.go
@@ -2,54 +2,73 @@ package handlers
 
 import (
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/url"
 
 	"github.com/keratin/authn-server/app"
 	"github.com/keratin/authn-server/app/tokens/oauth"
 	"github.com/keratin/authn-server/lib"
+	"github.com/keratin/authn-server/lib/route"
+	"github.com/keratin/authn-server/lib/smart_on_fhir"
 )
 
 func GetFhirLaunch(app *app.App, providerName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		redirectURI := app.Config.AuthNURL.String() + "/fhir/" + providerName + "/return"
 		provider := app.SmartOnFhirProviders[providerName]
 		issuer := r.FormValue("iss")
 		launch := r.FormValue("launch")
+		redirectURI := r.FormValue("redirect_uri")                                           // redirect URI to the UI
+		authnReturnUri := app.Config.AuthNURL.String() + "/fhir/" + providerName + "/return" // Authn to return to after login
 
-		// Not currently used, but could be:
-		// metadata := new(OpenIDConfiguration)
-		// discoverAuthServer(issuer, metadata)
+		if route.FindDomain(redirectURI, app.Config.ApplicationDomains) == nil {
+			app.Reporter.ReportRequestError(errors.New("unknown redirect domain"), r)
+			failsafe := app.Config.ApplicationDomains[0].URL()
+			http.Redirect(w, r, failsafe.String(), http.StatusSeeOther)
+			return
+		}
+
+		// fail handler
+		fail := func(err error) {
+			app.Reporter.ReportRequestError(err, r)
+			redirectFailure(w, r, redirectURI)
+		}
 
 		// set nonce in a secured cookie
 		bytes, err := lib.GenerateToken()
 		if err != nil {
-			WriteData(w, http.StatusBadRequest, map[string]interface{}{"error": err.Error()})
+			fail(err)
+			return
 		}
 		nonce := base64.StdEncoding.EncodeToString(bytes)
 		http.SetCookie(w, nonceCookie(app.Config, string(nonce)))
 
 		// save nonce and return URL into state param
-		// TODO: configure and store the URL of the application to redirect to
-		// after the authorization process is complete. This is NOT the AuthN Server URL,
-		// but the URL of the application
 		stateToken, err := oauth.New(app.Config, string(nonce), redirectURI)
 		if err != nil {
-			WriteData(w, http.StatusBadRequest, map[string]interface{}{"error": err.Error()})
+			fail(err)
+			return
 		}
 		state, _ := stateToken.Sign(app.Config.OAuthSigningKey)
 
 		// Create the URL to redirect to
-		finalRedirectUrl, _ := url.Parse(provider.Config(redirectURI).AuthCodeURL(state))
-
-		// Add the launch and aud parameters to the URL
-		// http://www.hl7.org/fhir/smart-app-launch/app-launch.html#request-4
-		values := finalRedirectUrl.Query()
-		values.Add("launch", launch)
-		values.Add("aud", issuer)
-		finalRedirectUrl.RawQuery = values.Encode()
+		// returnUrl, _ := buildAuthnReturnUrl(authnReturnUri, provider, state, launch, issuer)
+		returnUrl, _ := buildAuthnReturnUrl(authnReturnUri, provider, state, launch, issuer)
 
 		// Redirect user to the final URL
-		http.Redirect(w, r, finalRedirectUrl.String(), http.StatusSeeOther)
+		http.Redirect(w, r, returnUrl.String(), http.StatusSeeOther)
 	}
+}
+
+func buildAuthnReturnUrl(baseUri string, provider smart_on_fhir.FhirProvider, state string, launch string, issuer string) (*url.URL, error) {
+	returnUrl, err := url.Parse(provider.Config(baseUri).AuthCodeURL(state))
+
+	// Add the launch and aud parameters to the URL
+	// http://www.hl7.org/fhir/smart-app-launch/app-launch.html#request-4
+	values := returnUrl.Query()
+	values.Add("launch", launch)
+	values.Add("aud", issuer)
+	returnUrl.RawQuery = values.Encode()
+
+	return returnUrl, err
 }

--- a/server/handlers/get_fhir_return.go
+++ b/server/handlers/get_fhir_return.go
@@ -1,17 +1,19 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/keratin/authn-server/app"
+	"github.com/keratin/authn-server/app/services"
+	"github.com/keratin/authn-server/lib/oauth"
 	"github.com/keratin/authn-server/lib/smart_on_fhir"
+	"github.com/keratin/authn-server/server/sessions"
 	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
 )
 
 func GetFhirReturn(app *app.App, providerName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println("---- Starting: GetFhirReturn ----")
 
 		provider := app.SmartOnFhirProviders[providerName]
 		// exchange code for tokens and user info
@@ -19,7 +21,6 @@ func GetFhirReturn(app *app.App, providerName string) http.HandlerFunc {
 		tokenUrl := provider.TokenUrl()
 		clientId := provider.ClientID()
 		clientSecret := provider.ClientSecret()
-
 		state, err := getState(app.Config, r)
 		if err != nil {
 			app.Reporter.ReportRequestError(errors.Wrap(err, "getState"), r)
@@ -37,44 +38,69 @@ func GetFhirReturn(app *app.App, providerName string) http.HandlerFunc {
 		// ===> exchange code for tokens and user info
 		tokenResponse, err := smart_on_fhir.RequestAccessToken(tokenUrl, clientId, clientSecret, r.FormValue("code"))
 		if err != nil {
-			fmt.Println("Error getting token:", err)
 			fail(err)
 			return
 		}
 		providerUser, err := provider.UserInfo(tokenResponse)
 		if err != nil {
-			fmt.Println("Error getting user info:", err)
 			fail(err)
 			return
 		}
 
-		fmt.Println("GetFhirReturn: providerUser:", providerUser.Email)
+		// ===> attempt to reconcile oauth identity information into an authn account and return a session token
+		sessionToken, err := getSessionFromOauth(app, providerUser, tokenResponse, r, providerName)
+		if err != nil {
+			fail(err)
+			return
+		}
+		// Return the signed session in a cookie
+		sessions.Set(app.Config, w, sessionToken)
 
-		// TODO: Figure out proper way to extract user information to link with OAuth account
+		// Set FHIR Information in a cookie
+		cookie := &http.Cookie{
+			Name:     "fhir_session",
+			Value:    tokenResponse.AccessToken + "::" + tokenResponse.PatientFhirId,
+			Path:     "/fhir/",
+			Secure:   app.Config.ForceSSL,
+			HttpOnly: false,
+			SameSite: app.Config.SameSiteComputed(),
+			MaxAge:   100000,
+		}
+		http.SetCookie(w, cookie)
 
-		// attempt to reconcile oauth identity information into an authn account
-		// sessionAccountID := sessions.GetAccountID(r)
-		// account, err := services.IdentityReconciler(app.AccountStore, app.Config, providerName, providerUser, tok, sessionAccountID)
-		// if err != nil {
-		// 	// fail(err)
-		// 	return
-		// }
-
-		// // identityToken is not returned in this flow. it must be imported by the frontend like a SSO session.
-		// sessionToken, _, err := services.SessionCreator(
-		// 	app.AccountStore, app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, app.Reporter,
-		// 	account.ID, &app.Config.ApplicationDomains[0], sessions.GetRefreshToken(r),
-		// )
-		// if err != nil {
-		// 	// fail(errors.Wrap(err, "NewSession"))
-		// 	return
-		// }
-
-		// // Return the signed session in a cookie
-		// sessions.Set(app.Config, w, sessionToken)
-
-		// redirect back to frontend (success or failure)
-		fmt.Println("===> state.Destination:", state.Destination)
+		// redirect to the destination
 		http.Redirect(w, r, state.Destination, http.StatusSeeOther)
 	}
+}
+
+func getSessionFromOauth(app *app.App, providerUser *smart_on_fhir.UserInfo, tokenResponse *smart_on_fhir.FhirTokenResponse, r *http.Request, providerName string) (string, error) {
+	// attempt to reconcile oauth identity information into an authn account
+	sessionAccountID := sessions.GetAccountID(r)
+
+	// Cast smartOnfhir structs to oauth structs b/c I don't know how to type cast them
+	oauthProviderUser := &oauth.UserInfo{
+		ID:    providerUser.ID,
+		Email: providerUser.Email,
+	}
+
+	tok := &oauth2.Token{
+		AccessToken: tokenResponse.AccessToken,
+	}
+
+	// Use oauth service to reconcile with existing identities
+	account, err := services.IdentityReconciler(app.AccountStore, app.Config, providerName, oauthProviderUser, tok, sessionAccountID)
+	if err != nil {
+		return "", err
+	}
+
+	// identityToken is not returned in this flow. it must be imported by the frontend like a SSO session.
+	sessionToken, _, err := services.SessionCreator(
+		app.AccountStore, app.RefreshTokenStore, app.KeyStore, app.Actives, app.Config, app.Reporter,
+		account.ID, &app.Config.ApplicationDomains[0], sessions.GetRefreshToken(r),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return sessionToken, nil
 }


### PR DESCRIPTION
### Whats Up
Wrap up the FHIR launch for Epic

**FHIR Launch.go**
1. Split `returnURL` from `redirectUri`. The first is where Epic redirects to after auth succeeds (keratin), the 2nd is where keratin redirects to after keratin auth succeeds

**FHIR Return.go**
1. Refactor for legibility
2. Use the code from `oauth_return.go` to find or create the account
3. Return the access token and patient id in a cookie
4. Redirect to Patient App UI